### PR TITLE
chore: remove bun dependency from package.json and clean up yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/k6": "^1.0.0",
     "@types/node": "^22.10.2",
     "@types/stream-fork": "^1.0.5",
-    "bun": "^1.1.39",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-eslint-plugin": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,83 +1205,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oven/bun-darwin-aarch64@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-darwin-aarch64@npm:1.2.15"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-darwin-x64-baseline@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-darwin-x64-baseline@npm:1.2.15"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-darwin-x64@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-darwin-x64@npm:1.2.15"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-aarch64-musl@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-aarch64-musl@npm:1.2.15"
-  conditions: os=linux & cpu=aarch64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-aarch64@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-aarch64@npm:1.2.15"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64-baseline@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-x64-baseline@npm:1.2.15"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64-musl-baseline@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-x64-musl-baseline@npm:1.2.15"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64-musl@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-x64-musl@npm:1.2.15"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-linux-x64@npm:1.2.15"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-windows-x64-baseline@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-windows-x64-baseline@npm:1.2.15"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-windows-x64@npm:1.2.15":
-  version: 1.2.15
-  resolution: "@oven/bun-windows-x64@npm:1.2.15"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8":
   version: 2.3.15
   resolution: "@peculiar/asn1-schema@npm:2.3.15"
@@ -2849,7 +2772,6 @@ __metadata:
     "@types/node": "npm:^22.10.2"
     "@types/stream-fork": "npm:^1.0.5"
     axios: "npm:^1.7.9"
-    bun: "npm:^1.1.39"
     eslint: "npm:^9.0.0"
     eslint-config-prettier: "npm:^10.0.0"
     eslint-plugin-eslint-plugin: "npm:^6.3.1"
@@ -3165,52 +3087,6 @@ __metadata:
   version: 0.0.6
   resolution: "buildcheck@npm:0.0.6"
   checksum: 10c0/8cbdb89f41bc484b8325f4828db4135b206a0dffb641eb6cdb2b7022483c45dd0e5aac6d820c9a67bdd2caab3a02c76d7ceec7bd9ec494b5a2270d2806b01a76
-  languageName: node
-  linkType: hard
-
-"bun@npm:^1.1.39":
-  version: 1.2.15
-  resolution: "bun@npm:1.2.15"
-  dependencies:
-    "@oven/bun-darwin-aarch64": "npm:1.2.15"
-    "@oven/bun-darwin-x64": "npm:1.2.15"
-    "@oven/bun-darwin-x64-baseline": "npm:1.2.15"
-    "@oven/bun-linux-aarch64": "npm:1.2.15"
-    "@oven/bun-linux-aarch64-musl": "npm:1.2.15"
-    "@oven/bun-linux-x64": "npm:1.2.15"
-    "@oven/bun-linux-x64-baseline": "npm:1.2.15"
-    "@oven/bun-linux-x64-musl": "npm:1.2.15"
-    "@oven/bun-linux-x64-musl-baseline": "npm:1.2.15"
-    "@oven/bun-windows-x64": "npm:1.2.15"
-    "@oven/bun-windows-x64-baseline": "npm:1.2.15"
-  dependenciesMeta:
-    "@oven/bun-darwin-aarch64":
-      optional: true
-    "@oven/bun-darwin-x64":
-      optional: true
-    "@oven/bun-darwin-x64-baseline":
-      optional: true
-    "@oven/bun-linux-aarch64":
-      optional: true
-    "@oven/bun-linux-aarch64-musl":
-      optional: true
-    "@oven/bun-linux-x64":
-      optional: true
-    "@oven/bun-linux-x64-baseline":
-      optional: true
-    "@oven/bun-linux-x64-musl":
-      optional: true
-    "@oven/bun-linux-x64-musl-baseline":
-      optional: true
-    "@oven/bun-windows-x64":
-      optional: true
-    "@oven/bun-windows-x64-baseline":
-      optional: true
-  bin:
-    bun: bin/bun.exe
-    bunx: bin/bun.exe
-  checksum: 10c0/c1744098a723940f68b7fcc8508e28be0010003a79a48f6682cdf0215f1afb2b045ac256baaa2b2c858b888426e39b1a69cad3550a5a8d2a2581a5ea19025903
-  conditions: (os=darwin | os=linux | os=win32) & (cpu=arm64 | cpu=x64 | cpu=aarch64)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Having bun as a `devDependency` is making auto-drive (uses files-gateway as a submodule) fail due to an error building it.