### PR TITLE
fix: object mapping indexer node subscription improvements

### DIFF
--- a/common/rpc-apis/src/subspaceObjectListener.ts
+++ b/common/rpc-apis/src/subspaceObjectListener.ts
@@ -33,6 +33,10 @@ export const SubspaceRPCApi = createApiDefinition({
       params: defineUnvalidatedType<[number]>(),
       returns: defineUnvalidatedType<ArchivedSegmentHeader[]>(),
     },
+    subspace_acknowledgeArchivedSegmentHeader: {
+      params: defineUnvalidatedType<[number]>(),
+      returns: defineUnvalidatedType<void>(),
+    },
   },
   notifications: {
     subspace_object_mappings: {

--- a/common/rpc-apis/src/subspaceObjectListener.ts
+++ b/common/rpc-apis/src/subspaceObjectListener.ts
@@ -44,7 +44,7 @@ export const SubspaceRPCApi = createApiDefinition({
         defineUnvalidatedType<SubscriptionResult<ObjectMappingListEntry>>(),
     },
     subspace_archived_segment_header: {
-      content: defineUnvalidatedType<ArchivedSegmentHeader>(),
+      content: defineUnvalidatedType<SubscriptionResult<ArchivedSegmentHeader>>(),
     },
   },
 })

--- a/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingListener.spec.ts
@@ -23,6 +23,7 @@ describe('Object Mapping Listener', () => {
           subspace_subscribeObjectMappings: () => '123',
           subspace_subscribeArchivedSegmentHeader: () => '456',
           subspace_lastSegmentHeaders: () => [],
+          subspace_acknowledgeArchivedSegmentHeader: () => undefined,
         },
         callbacks: {
           onEveryOpen: params.callbacks?.onEveryOpen,

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -34,14 +34,37 @@ const mockSubscribeToArchivedSegmentHeader = () => {
             client?.api.subspace_subscribeArchivedSegmentHeader()
             client?.onNotification(
               'subspace_archived_segment_header',
-              (event) => {
+              async (event: {
+                v0: {
+                  segmentIndex: number
+                  segmentCommitment: string
+                  prevSegmentHeaderHash: string
+                  lastArchivedBlock: {
+                    number: number
+                    archivedProgress: { partial: number }
+                  }
+                }
+              }) => {
+                const segmentIndex = event.v0.segmentIndex
                 logger.info(
-                  `Processing archived segment header (segmentIndex=${event.v0.segmentIndex})`,
+                  `Processing archived segment header (segmentIndex=${segmentIndex})`,
                 )
                 logger.debug(
                   `Archived segment header: ${JSON.stringify(event)}`,
                 )
-                onArchivedSegmentHeader?.(event.v0.segmentIndex)
+
+                // Acknowledge receipt of the segment header to the node
+                try {
+                  await client?.api.subspace_acknowledgeArchivedSegmentHeader([
+                    segmentIndex,
+                  ])
+                } catch (error) {
+                  logger.error(
+                    `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
+                  )
+                }
+
+                onArchivedSegmentHeader?.(segmentIndex)
               },
             )
           },
@@ -50,6 +73,7 @@ const mockSubscribeToArchivedSegmentHeader = () => {
           subspace_lastSegmentHeaders: async () => [],
           subspace_subscribeObjectMappings: () => '123',
           subspace_subscribeArchivedSegmentHeader: () => '456',
+          subspace_acknowledgeArchivedSegmentHeader: () => undefined,
         },
       })
     })

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -13,6 +13,18 @@ import { config } from '../src/config.js'
 let client: ReturnType<typeof SubspaceRPCApi.createMockServerClient> | null =
   null
 
+type ArchivedSegmentHeader = {
+  v0: {
+    segmentIndex: number
+    segmentCommitment: string
+    prevSegmentHeaderHash: string
+    lastArchivedBlock: {
+      number: number
+      archivedProgress: { partial: number }
+    }
+  }
+}
+
 const mockSubscribeToArchivedSegmentHeader = () => {
   jest
     .spyOn(segmentUseCase, 'subscribeToArchivedSegmentHeader')
@@ -29,44 +41,7 @@ const mockSubscribeToArchivedSegmentHeader = () => {
               `Subscribing to archived segment headers (lastSegmentIndex=${lastSegmentIndex})`,
             )
             // triggers a new subscription to archived segment headers
-            // ignores subscriptionId and processed events by name
-            // using client.onNotification('subspace_archived_segment_header')
             client?.api.subspace_subscribeArchivedSegmentHeader()
-            client?.onNotification(
-              'subspace_archived_segment_header',
-              async (event: {
-                v0: {
-                  segmentIndex: number
-                  segmentCommitment: string
-                  prevSegmentHeaderHash: string
-                  lastArchivedBlock: {
-                    number: number
-                    archivedProgress: { partial: number }
-                  }
-                }
-              }) => {
-                const segmentIndex = event.v0.segmentIndex
-                logger.info(
-                  `Processing archived segment header (segmentIndex=${segmentIndex})`,
-                )
-                logger.debug(
-                  `Archived segment header: ${JSON.stringify(event)}`,
-                )
-
-                // Acknowledge receipt of the segment header to the node
-                try {
-                  await client?.api.subspace_acknowledgeArchivedSegmentHeader([
-                    segmentIndex,
-                  ])
-                } catch (error) {
-                  logger.error(
-                    `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
-                  )
-                }
-
-                onArchivedSegmentHeader?.(segmentIndex)
-              },
-            )
           },
         },
         handlers: {
@@ -76,6 +51,32 @@ const mockSubscribeToArchivedSegmentHeader = () => {
           subspace_acknowledgeArchivedSegmentHeader: () => undefined,
         },
       })
+
+      // Register notification handler ONCE, outside of onEveryOpen
+      // This prevents duplicate handlers from accumulating on reconnect
+      client.onNotification(
+        'subspace_archived_segment_header',
+        async (event: ArchivedSegmentHeader) => {
+          const segmentIndex = event.v0.segmentIndex
+          logger.info(
+            `Processing archived segment header (segmentIndex=${segmentIndex})`,
+          )
+          logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
+
+          // Acknowledge receipt of the segment header to the node
+          try {
+            await client?.api.subspace_acknowledgeArchivedSegmentHeader([
+              segmentIndex,
+            ])
+          } catch (error) {
+            logger.error(
+              `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
+            )
+          }
+
+          onArchivedSegmentHeader?.(segmentIndex)
+        },
+      )
     })
 }
 

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -54,10 +54,8 @@ const mockSubscribeToArchivedSegmentHeader = () => {
 
       // Register notification handler ONCE, outside of onEveryOpen
       // This prevents duplicate handlers from accumulating on reconnect
-      client.onNotification(
-        'subspace_archived_segment_header',
-        async (event: ArchivedSegmentHeader) => {
-          const segmentIndex = event.v0.segmentIndex
+      client.onNotification('subspace_archived_segment_header', async (event) => {
+        const segmentIndex = event.result.v0.segmentIndex
           logger.info(
             `Processing archived segment header (segmentIndex=${segmentIndex})`,
           )
@@ -146,14 +144,17 @@ describe('Object Mapping Router', () => {
         client?.notificationClient.subspace_archived_segment_header(
           connection,
           {
-            v0: {
-              segmentIndex,
-              segmentCommitment: '',
-              prevSegmentHeaderHash: '',
-              lastArchivedBlock: {
-                number: 0,
-                archivedProgress: {
-                  partial: 0,
+            subscriptionId: 'test-subscription',
+            result: {
+              v0: {
+                segmentIndex,
+                segmentCommitment: '',
+                prevSegmentHeaderHash: '',
+                lastArchivedBlock: {
+                  number: 0,
+                  archivedProgress: {
+                    partial: 0,
+                  },
                 },
               },
             },

--- a/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
+++ b/services/object-mapping-indexer/__tests__/objectMappingRouter.spec.ts
@@ -13,18 +13,6 @@ import { config } from '../src/config.js'
 let client: ReturnType<typeof SubspaceRPCApi.createMockServerClient> | null =
   null
 
-type ArchivedSegmentHeader = {
-  v0: {
-    segmentIndex: number
-    segmentCommitment: string
-    prevSegmentHeaderHash: string
-    lastArchivedBlock: {
-      number: number
-      archivedProgress: { partial: number }
-    }
-  }
-}
-
 const mockSubscribeToArchivedSegmentHeader = () => {
   jest
     .spyOn(segmentUseCase, 'subscribeToArchivedSegmentHeader')

--- a/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
@@ -7,28 +7,28 @@ import { config } from '../../config.js'
 export const createObjectMappingListener = (): ObjectMappingListener => {
   return {
     start: () => {
-      const init = async () => {
-        logger.info('Subscribing to object mappings')
-        await client.api.subspace_subscribeObjectMappings()
-
-        client.onNotification('subspace_object_mappings', async (event) => {
-          logger.info(
-            `Processing object mapping (blockNumber=${event.result.blockNumber})`,
-          )
-          logger.debug(`Object mapping: ${JSON.stringify(event)}`)
-          await objectMappingUseCase.processObjectMapping(event.result)
-        })
-      }
-
       const client = SubspaceRPCApi.createClient({
         endpoint: config.nodeRpcUrl,
         reconnectInterval: 60_000,
         callbacks: {
-          onEveryOpen: init,
+          onEveryOpen: async () => {
+            logger.info('Subscribing to object mappings')
+            await client.api.subspace_subscribeObjectMappings()
+          },
           onReconnection: () => {
             logger.warn('Reconnecting to object mapping indexer')
           },
         },
+      })
+
+      // Register notification handler ONCE, outside of onEveryOpen
+      // This prevents duplicate handlers from accumulating on reconnect
+      client.onNotification('subspace_object_mappings', async (event) => {
+        logger.info(
+          `Processing object mapping (blockNumber=${event.result.blockNumber})`,
+        )
+        logger.debug(`Object mapping: ${JSON.stringify(event)}`)
+        await objectMappingUseCase.processObjectMapping(event.result)
       })
     },
   }

--- a/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
+++ b/services/object-mapping-indexer/src/services/objectMappingListener/index.ts
@@ -16,7 +16,13 @@ export const createObjectMappingListener = (): ObjectMappingListener => {
             await client.api.subspace_subscribeObjectMappings()
           },
           onReconnection: () => {
-            logger.warn('Reconnecting to object mapping indexer')
+            logger.warn('Reconnecting to object mapping subscription')
+          },
+          onClose: () => {
+            logger.warn('Object mapping subscription closed')
+          },
+          onError: (error) => {
+            logger.error(`Object mapping subscription error: ${error}`)
           },
         },
       })

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -49,34 +49,34 @@ const subscribeToArchivedSegmentHeader = async (
         // ignores subscriptionId and processed events by name
         // using client.onNotification('subspace_archived_segment_header')
         client!.api.subspace_subscribeArchivedSegmentHeader()
-        client!.onNotification(
-          'subspace_archived_segment_header',
-          async (event) => {
-            const segmentIndex = event.v0.segmentIndex
-            logger.info(
-              `Processing archived segment header (segmentIndex=${segmentIndex})`,
-            )
-            logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
-
-            // Acknowledge receipt of the segment header to the node
-            try {
-              await client!.api.subspace_acknowledgeArchivedSegmentHeader([
-                segmentIndex,
-              ])
-              logger.debug(
-                `Acknowledged archived segment header (segmentIndex=${segmentIndex})`,
-              )
-            } catch (error) {
-              logger.error(
-                `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
-              )
-            }
-
-            onArchivedSegmentHeader?.(segmentIndex)
-          },
-        )
       },
     },
+  })
+
+  // Register notification handler ONCE, outside of onEveryOpen
+  // This prevents duplicate handlers from accumulating on reconnect
+  client.onNotification('subspace_archived_segment_header', async (event) => {
+    const segmentIndex = event.v0.segmentIndex
+    logger.info(
+      `Processing archived segment header (segmentIndex=${segmentIndex})`,
+    )
+    logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
+
+    // Acknowledge receipt of the segment header to the node
+    try {
+      await client!.api.subspace_acknowledgeArchivedSegmentHeader([
+        segmentIndex,
+      ])
+      logger.debug(
+        `Acknowledged archived segment header (segmentIndex=${segmentIndex})`,
+      )
+    } catch (error) {
+      logger.error(
+        `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
+      )
+    }
+
+    onArchivedSegmentHeader?.(segmentIndex)
   })
 }
 

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -50,6 +50,15 @@ const subscribeToArchivedSegmentHeader = async (
         // using client.onNotification('subspace_archived_segment_header')
         client!.api.subspace_subscribeArchivedSegmentHeader()
       },
+      onReconnection: () => {
+        logger.warn('Reconnecting to archived segment header subscription')
+      },
+      onClose: () => {
+        logger.warn('Archived segment header subscription closed')
+      },
+      onError: (error) => {
+        logger.error(`Archived segment header subscription error: ${error}`)
+      },
     },
   })
 

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -42,13 +42,32 @@ const subscribeToArchivedSegmentHeader = async (
         // ignores subscriptionId and processed events by name
         // using client.onNotification('subspace_archived_segment_header')
         client.api.subspace_subscribeArchivedSegmentHeader()
-        client.onNotification('subspace_archived_segment_header', (event) => {
-          logger.info(
-            `Processing archived segment header (segmentIndex=${event.v0.segmentIndex})`,
-          )
-          logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
-          onArchivedSegmentHeader?.(event.v0.segmentIndex)
-        })
+        client.onNotification(
+          'subspace_archived_segment_header',
+          async (event) => {
+            const segmentIndex = event.v0.segmentIndex
+            logger.info(
+              `Processing archived segment header (segmentIndex=${segmentIndex})`,
+            )
+            logger.debug(`Archived segment header: ${JSON.stringify(event)}`)
+
+            // Acknowledge receipt of the segment header to the node
+            try {
+              await client.api.subspace_acknowledgeArchivedSegmentHeader([
+                segmentIndex,
+              ])
+              logger.debug(
+                `Acknowledged archived segment header (segmentIndex=${segmentIndex})`,
+              )
+            } catch (error) {
+              logger.error(
+                `Failed to acknowledge archived segment header (segmentIndex=${segmentIndex}): ${error}`,
+              )
+            }
+
+            onArchivedSegmentHeader?.(segmentIndex)
+          },
+        )
       },
     },
   })

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -64,6 +64,8 @@ const subscribeToArchivedSegmentHeader = async (
 
   // Register notification handler ONCE, outside of onEveryOpen
   // This prevents duplicate handlers from accumulating on reconnect
+  // Capture client reference at registration time to avoid stale reference issues
+  const registeredClient = client
   client.onNotification('subspace_archived_segment_header', async (event) => {
     const segmentIndex = event.result.v0.segmentIndex
     logger.info(
@@ -73,7 +75,7 @@ const subscribeToArchivedSegmentHeader = async (
 
     // Acknowledge receipt of the segment header to the node
     try {
-      await client!.api.subspace_acknowledgeArchivedSegmentHeader([
+      await registeredClient!.api.subspace_acknowledgeArchivedSegmentHeader([
         segmentIndex,
       ])
       logger.debug(

--- a/services/object-mapping-indexer/src/useCases/segment.ts
+++ b/services/object-mapping-indexer/src/useCases/segment.ts
@@ -65,7 +65,7 @@ const subscribeToArchivedSegmentHeader = async (
   // Register notification handler ONCE, outside of onEveryOpen
   // This prevents duplicate handlers from accumulating on reconnect
   client.onNotification('subspace_archived_segment_header', async (event) => {
-    const segmentIndex = event.v0.segmentIndex
+    const segmentIndex = event.result.v0.segmentIndex
     logger.info(
       `Processing archived segment header (segmentIndex=${segmentIndex})`,
     )


### PR DESCRIPTION
### Summary

Fixes WebSocket subscription reliability issues in the object mapping indexer that caused silent failures where the indexer would stop receiving new data.

### Context

On January 13-14, 2026, the production indexer fell behind the network (stuck at segment 872 while network was at 873). The failure was completely silent - no errors in logs. Investigation revealed multiple bugs in WebSocket subscription handling that could cause the indexer to stop receiving notifications after reconnections.

The Subspace node logs showed:

```
WARN: Archived segment notification was not acknowledged and reached timeout
```

### Secondary Issue Uncovered

Fixing the above uncovered a secondary issue with property access:

**Root Cause**: The `@autonomys/rpc` library wraps notification payloads in a `SubscriptionResult` 
structure (`{subscription: string, result: T}`), but the segment header handler was accessing 
`event.v0.segmentIndex` instead of `event.result.v0.segmentIndex`.

**Impact**: When the node sent a segment header notification, the handler crashed with:

```
TypeError: Cannot read properties of undefined (reading 'segmentIndex')
```

The way the subscription handler was setup before the connection improvements above meant the failure was not being logged and the connection was silently dropping. This meant a restart of the indexer would sync from the "catch-up" phase, switch to real-time subscriptions but then the next archived segment would kill the connection and cease progress.

### Changes

- **Add segment header acknowledgment** - Call `subspace_acknowledgeArchivedSegmentHeader` after receiving notifications to prevent node timeout warnings
- **Fix client variable shadowing** - `unsubscribeFromArchivedSegmentHeader()` was broken because a local variable shadowed the module-level client
- **Fix duplicate notification handlers** - Handlers were registered inside `onEveryOpen`, causing them to accumulate on each reconnection
- **Add connection lifecycle logging** - Log reconnection, close, and error events for better observability
- **Fixed subscription notification property access** - Fixed type definition to use `SubscriptionResult<ArchivedSegmentHeader>` and property access to `event.result.v0.segmentIndex`.

### Testing

- All existing tests pass
- Updated test mocks to match fixed implementation
- Property accessor tested locally on segment 891