### PR TITLE
fix: Add Subspace node Docker image tag to deployment workflow

### DIFF
--- a/.github/workflows/image-deployment.yml
+++ b/.github/workflows/image-deployment.yml
@@ -22,6 +22,10 @@ on:
         description: 'Docker image tag visit in the releases page at (https://github.com/autonomys/auto-files-gateway/pkgs/container/file-retriever)'
         required: false
         type: string
+      node_image_tag:
+        description: 'Docker image tag for the subspace-node service (https://github.com/autonomys/subspace/pkgs/container/node)'
+        required: false
+        type: string
 env:
   INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
   INFISICAL_SECRET: ${{ secrets.INFISICAL_SECRET }}
@@ -48,6 +52,7 @@ jobs:
             GATEWAY_IMAGE_TAG="${{ github.event.inputs.gateway_image_tag }}"
             INDEXER_IMAGE_TAG="${{ github.event.inputs.indexer_image_tag }}"
             FILE_RETRIEVER_IMAGE_TAG="${{ github.event.inputs.file_retriever_image_tag }}"
+            NODE_IMAGE_TAG="${{ github.event.inputs.node_image_tag }}"
             echo "Using manual inputs"
           else
             # Push trigger - use defaults
@@ -55,6 +60,7 @@ jobs:
             GATEWAY_IMAGE_TAG=""  # or set a default like "latest"
             INDEXER_IMAGE_TAG=""  # or set a default like "latest"
             FILE_RETRIEVER_IMAGE_TAG=""  # or set a default like "latest"
+            NODE_IMAGE_TAG=""
             echo "Using push defaults"
           fi
 
@@ -62,6 +68,7 @@ jobs:
           echo "gateway_image_tag=$GATEWAY_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "indexer_image_tag=$INDEXER_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "file_retriever_image_tag=$FILE_RETRIEVER_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "node_image_tag=$NODE_IMAGE_TAG" >> $GITHUB_OUTPUT
 
           echo "Final parameters:"
           echo "  Target machines: $TARGET_MACHINES"
@@ -101,6 +108,7 @@ jobs:
             -e "gateway_image_tag=${{ steps.params.outputs.gateway_image_tag }}" \
             -e "indexer_image_tag=${{ steps.params.outputs.indexer_image_tag }}" \
             -e "file_retriever_image_tag=${{ steps.params.outputs.file_retriever_image_tag }}" \
+            -e "node_image_tag=${{ steps.params.outputs.node_image_tag }}" \
             -e "infisical_client_id=${{ secrets.INFISICAL_CLIENT_ID }}" \
             -e "infisical_secret=${{ secrets.INFISICAL_SECRET }}" \
             -e "infisical_project_id=${{ secrets.INFISICAL_PROJECT_ID }}" \

--- a/ansible/auto-files-gateway-deployment.yaml
+++ b/ansible/auto-files-gateway-deployment.yaml
@@ -48,6 +48,12 @@
       when: gateway_image_tag is defined and gateway_image_tag != ''
       register: hello_output
 
+    - name: Update NODE_DOCKER_TAG in folder '/{{ matched_group }}' to {{ node_image_tag }}
+      ansible.builtin.shell: |
+        infisical secrets --projectId {{ infisical_project_id }} --path /{{ matched_group }} --env prod --token {{ login_cmd.stdout }} set NODE_DOCKER_TAG={{ node_image_tag }}
+      when: node_image_tag is defined and node_image_tag != ''
+      register: hello_output
+
     - name: Update .env
       ansible.builtin.shell: |
         env_file=$(infisical export --projectId {{ infisical_project_id }} --path /{{ matched_group }} --env prod --token {{ login_cmd.stdout }})


### PR DESCRIPTION
Add `node_image_tag` input to the deployment workflow and Ansible playbook so `NODE_DOCKER_TAG` (used by the `subspace-node` service) can be updated through the standard deployment pipeline instead of requiring manual Infisical changes.