### PR TITLE
fix: omit Content-Length for compressed file responses

### DIFF
--- a/services/file-retriever/src/http/controllers/file.ts
+++ b/services/file-retriever/src/http/controllers/file.ts
@@ -75,11 +75,18 @@ fileRouter.get(
         `filename="${encodeURIComponent(file.filename)}"`,
       )
     }
-    if (file.size) {
+    // Only advertise a fixed Content-Length when the bytes on the wire match
+    // file.size. For ZLIB-compressed files the gateway streams the *compressed*
+    // bytes while file.size is the *decompressed* size, so sending Content-Length
+    // would corrupt the transfer (Content-Length/body mismatch makes clients
+    // fail the body read — e.g. browsers show "Failed to fetch" / broken images
+    // when previewing). In that case we omit it and rely on chunked transfer.
+    if (file.encoding) {
+      if (!rawMode) {
+        res.set('Content-Encoding', file.encoding)
+      }
+    } else if (file.size) {
       res.set('Content-Length', file.size.toString())
-    }
-    if (file.encoding && !rawMode) {
-      res.set('Content-Encoding', file.encoding)
     }
 
     logger.debug(


### PR DESCRIPTION
For ZLIB-compressed, unencrypted files the gateway streams the *compressed* bytes with `Content-Encoding: deflate`, but it was setting `Content-Length` to the *decompressed* size (nodeMetadata.size). The resulting Content-Length/body mismatch corrupts the transfer: clients fail the response body read, so browsers previewing such files show "Failed to fetch" (fetch) or a broken image (<img>), while downloads via the backend still work.

Only advertise a fixed Content-Length when the bytes on the wire match file.size (uncompressed responses). When the body is compressed, set Content-Encoding and rely on chunked transfer encoding instead.

Resolves https://github.com/autonomys/auto-files-gateway/issues/165