### PR TITLE
fix(file-retriever): verify zlib before setting deflate encoding (#169)

### DIFF
--- a/services/file-retriever/__tests__/compression.spec.ts
+++ b/services/file-retriever/__tests__/compression.spec.ts
@@ -1,0 +1,100 @@
+import { deflateSync } from 'zlib'
+import { deflateSync as fflateRawDeflateSync, zlibSync } from 'fflate'
+import { MetadataType, IPLDNodeData } from '@autonomys/auto-dag-data'
+import { jest } from '@jest/globals'
+import { isZlibCompressed } from '../src/utils/compression.js'
+import { dsnFetcher } from '../src/services/dsnFetcher.js'
+
+describe('isZlibCompressed', () => {
+  it('recognizes a valid zlib stream (node zlib)', () => {
+    const compressed = deflateSync(Buffer.from('hello world'.repeat(100)))
+    expect(isZlibCompressed(compressed)).toBe(true)
+  })
+
+  it('recognizes a valid zlib stream (fflate, as used by auto-dag-data)', () => {
+    const compressed = Buffer.from(
+      zlibSync(new TextEncoder().encode('hello world'.repeat(100))),
+    )
+    expect(isZlibCompressed(compressed)).toBe(true)
+  })
+
+  it('rejects an uncompressed PNG (issue #169 repro)', () => {
+    // PNG signature + start of IHDR — the broken bafkr6ia5… case
+    const png = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52,
+    ])
+    expect(isZlibCompressed(png)).toBe(false)
+  })
+
+  it('rejects literal JSON bytes (issue #169 repro)', () => {
+    const json = Buffer.from('{\n  "header": {\n    "agentName": "x"')
+    expect(isZlibCompressed(json)).toBe(false)
+  })
+
+  it('rejects raw deflate without a zlib wrapper', () => {
+    const raw = Buffer.from(
+      fflateRawDeflateSync(new TextEncoder().encode('abc'.repeat(50))),
+    )
+    // raw deflate has no zlib header; should not be misidentified
+    expect(isZlibCompressed(raw)).toBe(false)
+  })
+
+  it('rejects buffers shorter than the header', () => {
+    expect(isZlibCompressed(Buffer.from([0x78]))).toBe(false)
+    expect(isZlibCompressed(Buffer.alloc(0))).toBe(false)
+  })
+})
+
+describe('dsnFetcher.isActuallyCompressed', () => {
+  const cid = 'bafkr6idz7htrqhks6xyntulrqfyevx3k5qrhptbmgoxlmbss65yi3u25ym'
+
+  const chunks = [
+    {
+      cid,
+      links: [],
+      type: MetadataType.File,
+      linkDepth: 0,
+      blockHeight: 0,
+      blockHash: '',
+      extrinsicId: '',
+      extrinsicHash: '',
+      indexInBlock: 0,
+      blake3Hash: '',
+      timestamp: new Date(),
+    },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const mockFirstChunkData = (data: Buffer) => {
+    jest.spyOn(dsnFetcher, 'getFileChunks').mockResolvedValue(chunks)
+    jest.spyOn(dsnFetcher, 'fetchNode').mockResolvedValue({
+      Data: IPLDNodeData.encode({
+        type: MetadataType.File,
+        data,
+      }),
+      Links: [],
+    })
+  }
+
+  it('returns false for flagged-but-uncompressed bytes', async () => {
+    mockFirstChunkData(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]))
+    await expect(dsnFetcher.isActuallyCompressed(cid)).resolves.toBe(false)
+  })
+
+  it('returns true for genuinely zlib-compressed bytes', async () => {
+    mockFirstChunkData(deflateSync(Buffer.from('payload'.repeat(50))))
+    await expect(dsnFetcher.isActuallyCompressed(cid)).resolves.toBe(true)
+  })
+
+  it('returns false when there are no chunks', async () => {
+    jest.spyOn(dsnFetcher, 'getFileChunks').mockResolvedValue([])
+    await expect(dsnFetcher.isActuallyCompressed(cid)).resolves.toBe(false)
+  })
+})

--- a/services/file-retriever/src/http/controllers/file.ts
+++ b/services/file-retriever/src/http/controllers/file.ts
@@ -83,10 +83,23 @@ fileRouter.get(
     })
     res.setHeader('x-file-origin', fromCache ? 'cache' : 'gateway')
 
+    const downloadMetadata = DownloadMetadataFactory.fromIPLDData(metadata)
+
+    // Some stored objects are flagged `compression: ZLIB` in their metadata while
+    // their actual node bytes are uncompressed (autonomys/auto-files-gateway#169).
+    // Trusting the flag makes the gateway advertise `Content-Encoding: deflate`
+    // (full-body path) or attempt a server-side inflate (range path) over plaintext,
+    // breaking the response for any client that honors the encoding. Verify against
+    // the real bytes and serve as uncompressed when the flag doesn't match. This
+    // runs for both full-body and range responses since both flow through here.
+    if (downloadMetadata.isCompressed && !downloadMetadata.isEncrypted) {
+      downloadMetadata.isCompressed = await dsnFetcher.isActuallyCompressed(cid)
+    }
+
     const downloadResult = handleDownloadResponseHeaders(
       req,
       res,
-      DownloadMetadataFactory.fromIPLDData(metadata),
+      downloadMetadata,
       {
         byteRange,
         rawMode,

--- a/services/file-retriever/src/services/dsnFetcher.ts
+++ b/services/file-retriever/src/services/dsnFetcher.ts
@@ -18,6 +18,7 @@ import { z } from 'zod'
 import { PBNode } from '@ipld/dag-pb'
 import { HttpError } from '../http/middlewares/error.js'
 import { safeIPLDDecode } from '../utils/dagData.js'
+import { isZlibCompressed } from '../utils/compression.js'
 import mime from 'mime-types'
 import { config } from '../config.js'
 import { logger } from '../drivers/logger.js'
@@ -326,6 +327,46 @@ const getFileMetadata = (
   }
 }
 
+/**
+ * Verifies whether a file flagged as ZLIB-compressed is *actually* stored as a
+ * valid zlib stream by inspecting the leading bytes of its first chunk.
+ *
+ * Some stored objects carry `compression: ZLIB` metadata while their node bytes
+ * are plain (uncompressed) — see autonomys/auto-files-gateway#169. Serving those
+ * with `Content-Encoding: deflate` (or inflating them server-side) corrupts the
+ * response, so callers should use this to decide how to treat the body rather
+ * than trusting the metadata flag alone.
+ *
+ * @returns true if the first chunk's bytes are a valid zlib stream; false when
+ *   the file is not actually compressed (or the bytes can't be inspected).
+ */
+const isActuallyCompressed = async (cid: string): Promise<boolean> => {
+  try {
+    const chunks = await dsnFetcher.getFileChunks(cid)
+    const firstChunk = chunks[0]
+    if (!firstChunk) {
+      return false
+    }
+
+    const node = await dsnFetcher.fetchNode(
+      firstChunk.cid,
+      chunks.map((e) => e.cid),
+    )
+    const decoded = safeIPLDDecode(node)
+    const data = decoded?.data
+    if (!data || data.length === 0) {
+      return false
+    }
+
+    return isZlibCompressed(Buffer.from(data))
+  } catch (error) {
+    logger.warn(
+      `Failed to verify actual compression (cid=${cid}); assuming uncompressed; error=${error}`,
+    )
+    return false
+  }
+}
+
 const fetchFile = async (
   cid: string,
   options?: FileCacheOptions,
@@ -530,4 +571,5 @@ export const dsnFetcher = {
   fetchNodeMetadata,
   getFileChunks,
   getFileMetadata,
+  isActuallyCompressed,
 }

--- a/services/file-retriever/src/utils/compression.ts
+++ b/services/file-retriever/src/utils/compression.ts
@@ -1,0 +1,38 @@
+/**
+ * Detects whether a buffer begins with a valid zlib stream header.
+ *
+ * `@autonomys/auto-dag-data` compresses with fflate's `Zlib`, which produces a
+ * proper zlib wrapper (RFC 1950): a 2-byte header (CMF + FLG) followed by a
+ * deflate stream and an adler32 checksum. Some stored objects are flagged
+ * `compression: ZLIB` in their metadata while their actual node bytes are
+ * uncompressed (see autonomys/auto-files-gateway#169). Trusting the metadata
+ * flag alone makes the gateway advertise `Content-Encoding: deflate` (or attempt
+ * a server-side inflate) over plaintext, which corrupts the response.
+ *
+ * This validates the zlib header so callers can verify the bytes before
+ * treating them as compressed:
+ *  - CM (low nibble of CMF) must be 8 (the deflate compression method).
+ *  - CINFO (high nibble of CMF) must be <= 7 (window size <= 32K).
+ *  - The 16-bit value (CMF << 8 | FLG) must be a multiple of 31 (FCHECK).
+ *
+ * @param buffer - The leading bytes of the (claimed) compressed stream.
+ * @returns true only if the bytes are a structurally valid zlib stream header.
+ */
+export const isZlibCompressed = (buffer: Buffer): boolean => {
+  if (buffer.length < 2) {
+    return false
+  }
+
+  const cmf = buffer[0]
+  const flg = buffer[1]
+
+  const compressionMethod = cmf & 0x0f
+  const compressionInfo = cmf >> 4
+
+  if (compressionMethod !== 8 || compressionInfo > 7) {
+    return false
+  }
+
+  // FCHECK: the header is valid only when (CMF*256 + FLG) is a multiple of 31.
+  return (((cmf << 8) | flg) & 0xffff) % 31 === 0
+}


### PR DESCRIPTION
Files flagged compression: ZLIB but stored uncompressed caused broken previews: the gateway advertised Content-Encoding: deflate (full-body) or attempted a server-side inflate (range) over plaintext, yielding ERR_CONTENT_DECODING_FAILED.

Inspect the first chunk's bytes and only treat the body as compressed when it is a structurally valid zlib stream, overriding the metadata flag otherwise. Applies to both full-body and range responses since both flow through handleDownloadResponseHeaders.

- add isZlibCompressed() zlib-header validator
- add dsnFetcher.isActuallyCompressed() to verify stored bytes
- override isCompressed in the file controller before header handling
- tests covering the #169 PNG/JSON repro bytes and real zlib data

Closes #169 